### PR TITLE
Use PCI address instead of device name to retrieve metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+build/

--- a/README.md
+++ b/README.md
@@ -6,18 +6,34 @@ Pre-requisites:
 go mod tidy
 go build smc-exporter.go
 ```
+## Pre-built Binary
+A pre-built binary for linux amd64 servers is available to download in [Releases](https://github.com/smc-public/smc-exporter/releases)
+
 ## Installation
-After binary is built, you can simply copy it and use the example systemd service file to run as a service. eg.
+After a binary is built or downloaded, you can simply copy it and use the example systemd service file to run as a service. eg.
 ```
-cp smc-exporter /usr/local/bin
+cp smc-exporter /usr/local/bin/smc-exporter
 cp smc-exporter.service /usr/lib/systemd/system
 systemctl daemon-reload
 systemctl start smc-exporter
 ```
 This will give you a systemd service (smc-exporter) with the exporter running on the default port, 2112. If you want to use a different port, you will need to override the systemd unit or modify the service file before copying with the flag `-port {portnumber}`. 
+## Uninstalling
+To uninstall, stop and remove the service and remove the executeable.  eg.
+```
+systemctl stop smc-exporter
+systemctl disable smc-exporter
+rm /usr/lib/systemd/system/smc-exporter.service
+systemctl daemon-reload
+systemctl reset-failed
+rm /usr/local/bin/smc-exporter
+```
 
 ## Metrics information
 Currently smc-exporter only collects metrics for HCA transceivers running in Infiniband or Ethernet mode. The following metrics are collected:
+- state
+- physical state
+- speed
 - bias current
 - voltage
 - power Rx (for each lane)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+PLATFORMS=("linux/amd64")
+
+for platform in "${PLATFORMS[@]}"
+do
+    split=(${platform//\// })
+    GOOS=${split[0]} 
+    GOARCH=${split[1]}
+    CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -o build/smc-exporter-${GOOS}-${GOARCH}
+done

--- a/collector/nic-module.go
+++ b/collector/nic-module.go
@@ -65,7 +65,7 @@ type NicModuleCollector struct {
 func NewNicModuleCollector(namespace string) *NicModuleCollector {
 	laneLabel := []string{"lane"}
 	speedLabel := []string{"speed"}
-	stdLabels := []string{"mode", "caname", "netdev", "serial", "hostname", "systemserial", "slot"}
+	stdLabels := []string{"mode", "caname", "netdev", "serial", "hostname", "product_serial", "slot"}
 	return &NicModuleCollector{
 		state: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: namespace,


### PR DESCRIPTION
### Background

The current smc-exporter does not return metric information for eth0 and eth1 bonded interfaces.

### Description of the Change

Use lspci to identify mallanox nics and return pci addresses for them
Use pci address to collect metrics using mlxlink
Use existing code to lookup physical device names be they ethernet or infiniband
Add build script for building executable for configured platforms
Add state, physical state and speed metrics
Remove device label and add mode, caname, netdev labels
Rename systemserial to product_serial to align with node_exporter naming.

### Review instructions

Use the build script to build an executable.  The executable will be placed in a build directory
Copy the executable to a server with connect x devices
Run the executable  - smc-exporter-linux-amd64 -port 2114 
View metrics - wget 'http://localhost:2114/metrics'



