### PR TITLE
BAK-917 Add link state and max enabled speed metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,34 @@ Pre-requisites:
 go mod tidy
 go build smc-exporter.go
 ```
+## Pre-built Binary
+A pre-built binary for linux amd64 servers is available to download in [Releases](https://github.com/smc-public/smc-exporter/releases)
+
 ## Installation
-After binary is built, you can simply copy it and use the example systemd service file to run as a service. eg.
+After a binary is built or downloaded, you can simply copy it and use the example systemd service file to run as a service. eg.
 ```
-cp smc-exporter /usr/local/bin
+cp smc-exporter /usr/local/bin/smc-exporter
 cp smc-exporter.service /usr/lib/systemd/system
 systemctl daemon-reload
 systemctl start smc-exporter
 ```
 This will give you a systemd service (smc-exporter) with the exporter running on the default port, 2112. If you want to use a different port, you will need to override the systemd unit or modify the service file before copying with the flag `-port {portnumber}`. 
+## Uninstalling
+To uninstall, stop and remove the service and remove the executeable.  eg.
+```
+systemctl stop smc-exporter
+systemctl disable smc-exporter
+rm /usr/lib/systemd/system/smc-exporter.service
+systemctl daemon-reload
+systemctl reset-failed
+rm /usr/local/bin/smc-exporter
+```
 
 ## Metrics information
 Currently smc-exporter only collects metrics for HCA transceivers running in Infiniband or Ethernet mode. The following metrics are collected:
+- state
+- physical state
+- speed
 - bias current
 - voltage
 - power Rx (for each lane)

--- a/collector/nic-module.go
+++ b/collector/nic-module.go
@@ -65,7 +65,7 @@ type NicModuleCollector struct {
 func NewNicModuleCollector(namespace string) *NicModuleCollector {
 	laneLabel := []string{"lane"}
 	speedLabel := []string{"speed"}
-	stdLabels := []string{"mode", "caname", "netdev", "serial", "hostname", "systemserial", "slot"}
+	stdLabels := []string{"mode", "caname", "netdev", "serial", "hostname", "product_serial", "slot"}
 	return &NicModuleCollector{
 		state: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: namespace,


### PR DESCRIPTION
### What has changed

Collect mellanox link speed, state and physical state metrics using mlxlink.

###  How to review

1. Build smc-exporter executable using build.sh
2. Transfer build/smc-exporter-linux-amd64 to target server
3. Run smc-exporter-linux-amd64 using -port 2114 option
4. View metrics using http://localhost:2114/metrics
