### PR TITLE
BAK-964 Add slot label to metrics lost in recent changes

### DIFF
--- a/collector/nic-module.go
+++ b/collector/nic-module.go
@@ -532,6 +532,7 @@ func (n *NicModuleCollector) parseOutput(output string, device DeviceInfo, resp 
 
 	metrics.hostname = hostname
 	metrics.product_serial = systemserial
+	metrics.slot = slot
 
 	// mlxlink uses ansi escape codes to highlight values
 	// remove them so we can concentrate on content


### PR DESCRIPTION
### Background

Calculation of metrics / labels was reworked in the last round of chnages and apparently setting the slot label was missed.

### What has changed

Set slot label from sourced dmidecode slot info

### How to review

Build / deploy to a test server and run and confirm slot label is set.