### PR TITLE
Bak 974 Add basic unit tests of mlxlink output parsing

### DIFF
--- a/collector/nic-module.go
+++ b/collector/nic-module.go
@@ -437,7 +437,7 @@ func (n *NicModuleCollector) runMlxlink(hostname string, systemserial string, sl
 	cmd := exec.Command("mlxlink", "-d", device.pciAddress, "-m")
 	output, err := cmd.CombinedOutput()
 	if err == nil {
-		metrics := n.parseOutput(string(output), hostname, systemserial, slot, device)
+		metrics := parseOutput(string(output), hostname, systemserial, slot, device)
 		resp <- runMlxlinkResponse{metrics, false}
 	
 	} else {
@@ -623,7 +623,7 @@ func lookupKey(lookupMap map[string]string, lookupValue string) (string, bool) {
 }
 
 // Parse mlxlink data and set metrics
-func (n *NicModuleCollector) parseOutput(output string, hostname string, systemserial string, slot string, device DeviceInfo) PortMetrics {
+func parseOutput(output string, hostname string, systemserial string, slot string, device DeviceInfo) PortMetrics {
 	var metrics PortMetrics
 
 	metrics.mode = device.mode

--- a/collector/nic-module.go
+++ b/collector/nic-module.go
@@ -95,6 +95,89 @@ type runMlxlinkResponse struct {
 	result PortMetrics
 }
 
+var stateValues = map[string]float64{
+	"Disable":         0,
+	"Port PLL Down":   1,
+	"Polling":         2,
+	"Active":          3,
+	"Close port":      4,
+	"Physical LinkUp": 5,
+	"Sleep":           6,
+	"Rx disable":      7,
+	"Signal detect":   8,
+	"Receiver detect": 9,
+	"Sync peer":       10,
+	"Negotiation":     11,
+	"Training":        12,
+	"SubFSM active":   13,
+}
+
+var speed2bps = map[string]float64{
+	// IB
+	"IB-SDR":   10000000000,
+	"IB-DDR":   20000000000,
+	"IB-QDR":   40000000000,
+	"IB-FDR10": 40000000000,
+	"IB-FDR":   56000000000,
+	"IB-EDR":   100000000000,
+	"IB-HDR":   200000000000,
+	"IB-NDR":   400000000000,
+	"IB-XDR":   800000000000,
+	// Eth
+	"BaseTx100M": 100000000,
+	"BaseT1000M": 1000000000,
+	"BaseT10M":   10000000,
+	"CX":         1000000000,
+	"KX":         1000000000,
+	"CX4":        10000000000,
+	"KX4":        10000000000,
+	"BaseT10G":   10000000000,
+	"10GbE":      10000000000,
+	"20GbE":      20000000000,
+	"25GbE":      25000000000,
+	"40GbE":      40000000000,
+	"50GbE":      50000000000,
+	"56GbE":      56000000000,
+	"100GbE":     100000000000,
+	// Ext Eth
+	"100M": 100000000,
+	"1G":   1000000000,
+	"2.5G": 2500000000,
+	"5G":   5000000000,
+	"10G":  10000000000,
+	"40G":  40000000000,
+	"25G":  25000000000,
+	"50G":  50000000000,
+	"100G": 100000000000,
+	"200G": 200000000000,
+	"400G": 400000000000,
+	"800G": 800000000000,
+	"10M":  10000000,
+}
+
+var physicalStateValues = map[string]float64{
+	"Disabled":                   0,
+	"Initializing":               1,
+	"Recover Config":             2,
+	"Config Test":                3,
+	"Wait Remote Test":           4,
+	"Wait Config Enhanced":       5,
+	"Config Idle":                6,
+	"LinkUp":                     7,
+	"ETH_AN_FSM_ENABLE":          10,
+	"ETH_AN_FSM_XMIT_DISABLE":    11,
+	"ETH_AN_FSM_ABILITY_DETECT":  12,
+	"ETH_AN_FSM_ACK_DETECT":      13,
+	"ETH_AN_FSM_COMPLETE_ACK":    14,
+	"ETH_AN_FSM_AN_GOOD_CHECK":   15,
+	"ETH_AN_FSM_NEXT_PAGE_WAIT":  17,
+	"ETH_AN_FSM_LINK_STAT_CHECK": 18,
+	"ETH_AN_FSM_EXTRA_TUNE":      9,
+	"ETH_AN_FSM_FIX_REVERSALS":   10,
+	"ETH_AN_FSM_IB_FAIL":         11,
+	"ETH_AN_FSM_POST_LOCK_TUNE":  12,
+}
+
 func NewNicModuleCollector(namespace string) *NicModuleCollector {
 	laneLabel := []string{"lane"}
 	speedLabel := []string{"speed"}
@@ -589,19 +672,19 @@ func (n *NicModuleCollector) parseOutput(output string, device DeviceInfo, resp 
 		}
 
 		if matches := stateRegex.FindStringSubmatch(line); matches != nil {
-			if state, stateOK = stateValue(matches[1]); stateOK {
+			if state, stateOK = stateValues[matches[1]]; stateOK {
 				metrics.state = state
 			}
 		}
 
 		if matches := physicalStateRegex.FindStringSubmatch(line); matches != nil {
-			if physicalState, physicalStateOK = physicalStateValue(matches[1]); physicalStateOK {
+			if physicalState, physicalStateOK = physicalStateValues[matches[1]]; physicalStateOK {
 				metrics.physicalState = physicalState
 			}
 		}
 
 		if matches := speedRegex.FindStringSubmatch(line); matches != nil {
-			if speed, speedOK = gbps(matches[1]); speedOK {
+			if speed, speedOK = speed2bps[matches[1]]; speedOK {
 				metrics.speed = speed
 			}
 		}
@@ -659,113 +742,6 @@ func (n *NicModuleCollector) parseOutput(output string, device DeviceInfo, resp 
 func removeAnsiEscapeCodes(output string) string {
 	ansiEscapeCodeRegEx := regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
 	return ansiEscapeCodeRegEx.ReplaceAllString(output, "")
-}
-
-func stateValue(stateName string) (float64, bool) {
-	var stateValues = map[string]float64{
-		"Disable":         0,
-		"Port PLL Down":   1,
-		"Polling":         2,
-		"Active":          3,
-		"Close port":      4,
-		"Physical LinkUp": 5,
-		"Sleep":           6,
-		"Rx disable":      7,
-		"Signal detect":   8,
-		"Receiver detect": 9,
-		"Sync peer":       10,
-		"Negotiation":     11,
-		"Training":        12,
-		"SubFSM active":   13,
-	}
-
-	if value, exists := stateValues[stateName]; exists {
-		return value, true
-	} else {
-		return -1, false
-	}
-}
-
-func physicalStateValue(physicalStateName string) (float64, bool) {
-	var physicalStateValues = map[string]float64{
-		"Disabled":                   0,
-		"Initializing":               1,
-		"Recover Config":             2,
-		"Config Test":                3,
-		"Wait Remote Test":           4,
-		"Wait Config Enhanced":       5,
-		"Config Idle":                6,
-		"LinkUp":                     7,
-		"ETH_AN_FSM_ENABLE":          10,
-		"ETH_AN_FSM_XMIT_DISABLE":    11,
-		"ETH_AN_FSM_ABILITY_DETECT":  12,
-		"ETH_AN_FSM_ACK_DETECT":      13,
-		"ETH_AN_FSM_COMPLETE_ACK":    14,
-		"ETH_AN_FSM_AN_GOOD_CHECK":   15,
-		"ETH_AN_FSM_NEXT_PAGE_WAIT":  17,
-		"ETH_AN_FSM_LINK_STAT_CHECK": 18,
-		"ETH_AN_FSM_EXTRA_TUNE":      9,
-		"ETH_AN_FSM_FIX_REVERSALS":   10,
-		"ETH_AN_FSM_IB_FAIL":         11,
-		"ETH_AN_FSM_POST_LOCK_TUNE":  12,
-	}
-
-	if value, exists := physicalStateValues[physicalStateName]; exists {
-		return value, true
-	} else {
-		return -1, false
-	}
-}
-
-func gbps(speed string) (float64, bool) {
-	var speed2bps = map[string]float64{
-		// IB
-		"IB-SDR":   10000000000,
-		"IB-DDR":   20000000000,
-		"IB-QDR":   40000000000,
-		"IB-FDR10": 40000000000,
-		"IB-FDR":   56000000000,
-		"IB-EDR":   100000000000,
-		"IB-HDR":   200000000000,
-		"IB-NDR":   400000000000,
-		"IB-XDR":   800000000000,
-		// Eth
-		"BaseTx100M": 100000000,
-		"BaseT1000M": 1000000000,
-		"BaseT10M":   10000000,
-		"CX":         1000000000,
-		"KX":         1000000000,
-		"CX4":        10000000000,
-		"KX4":        10000000000,
-		"BaseT10G":   10000000000,
-		"10GbE":      10000000000,
-		"20GbE":      20000000000,
-		"25GbE":      25000000000,
-		"40GbE":      40000000000,
-		"50GbE":      50000000000,
-		"56GbE":      56000000000,
-		"100GbE":     100000000000,
-		// Ext Eth
-		"100M": 100000000,
-		"1G":   1000000000,
-		"2.5G": 2500000000,
-		"5G":   5000000000,
-		"10G":  10000000000,
-		"40G":  40000000000,
-		"25G":  25000000000,
-		"50G":  50000000000,
-		"100G": 100000000000,
-		"200G": 200000000000,
-		"400G": 400000000000,
-		"800G": 800000000000,
-		"10M":  10000000,
-	}
-
-	if value, exists := speed2bps[speed]; exists {
-		return value, true
-	} else {
-		return -1, false
-	}
 }
 
 func parseFloats(s string) []float64 {

--- a/collector/nic-module_test.go
+++ b/collector/nic-module_test.go
@@ -1,0 +1,71 @@
+package collector
+
+import (
+	"os"
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActiveEthernet(t *testing.T) {
+	bytes, _ := os.ReadFile("testdata/mlxlink_active_ethernet.txt")
+	testMlxlinkOutput := string(bytes)
+	deviceInfo := DeviceInfo{
+		pciAddress: "1b:00.0",
+		mode: "ethernet",
+		caName: "mlx5_0",
+		netDev: "ib0",
+	}
+	result := parseOutput(testMlxlinkOutput, "hostname", "systemserial", "slot", deviceInfo)
+	expected := PortMetrics{
+		mode: "ethernet",
+		caname: "mlx5_0",
+		netdev: "ib0",
+		serial: "5C2410312895",
+		hostname: "hostname",
+		product_serial: "systemserial",
+		slot: "slot",
+		state: 3,
+		physicalState: 10,
+		speed: 200000000000,
+		biasCurrent: []float64{7.800,8.220,7.840,8.100},
+		voltage: 3248900,
+		wavelength: 850,
+		transferDistance: 0.0,
+		rxPower: []float64{-3,-2,-1,0},
+		txPower: []float64{1,2,3,4},
+		attenuation: nil,
+	}
+	assert.Equal(t, expected, result)
+}
+
+func TestActiveInfiniband(t *testing.T) {
+	bytes, _ := os.ReadFile("testdata/mlxlink_active_infiniband.txt")
+	testMlxlinkOutput := string(bytes)
+	deviceInfo := DeviceInfo{
+		pciAddress: "1b:00.0",
+		mode: "ethernet",
+		caName: "mlx5_0",
+		netDev: "ib0",
+	}
+	result := parseOutput(testMlxlinkOutput, "hostname", "systemserial", "slot", deviceInfo)
+	expected := PortMetrics{
+		mode: "ethernet",
+		caname: "mlx5_0",
+		netdev: "ib0",
+		serial: "5C2410312316",
+		hostname: "hostname",
+		product_serial: "systemserial",
+		slot: "slot",
+		state: 3,
+		physicalState: 7,
+		speed: 400000000000,
+		biasCurrent: []float64{8.440,8.480,8.340,8.400},
+		voltage: 3258200,
+		wavelength: 858,
+		transferDistance: 0.0,
+		rxPower: []float64{-3,-2,-1,0},
+		txPower: []float64{1,2,3,4},
+		attenuation: nil,
+	}
+	assert.Equal(t, expected, result)
+}

--- a/collector/testdata/mlxlink_active_ethernet.txt
+++ b/collector/testdata/mlxlink_active_ethernet.txt
@@ -1,0 +1,82 @@
+
+Operational Info
+----------------
+State                           : Active
+Physical state                  : ETH_AN_FSM_ENABLE
+Speed                           : 200G
+Width                           : 4x
+FEC                             : Standard_RS-FEC - (544,514)
+Loopback Mode                   : No Loopback
+Auto Negotiation                : ON
+
+Supported Info
+--------------
+Enabled Link Speed (Ext.)       : 0x00003ff2 (200G_2X,200G_4X,100G_1X,100G_2X,100G_4X,50G_1X,50G_2X,40G,25G,10G,1G)
+Supported Cable Speed (Ext.)    : 0x00001000 (200G_4X)
+
+Troubleshooting Info
+--------------------
+Status Opcode                   : 0
+Group Opcode                    : N/A
+Recommendation                  : No issue was observed
+
+Tool Information
+----------------
+Firmware Version                : 28.39.2048
+amBER Version                   : 2.08
+MFT Version                     : mft 4.22.1-307
+
+Module Info
+-----------
+Identifier                      : QSFP_CMIS
+Compliance                      : 200GAUI-4,200GBASE-SR4
+Cable Technology                : 850 nm VCSEL
+Cable Type                      : Optical Module (separated)
+OUI                             : Mellanox
+Vendor Name                     : Firmus
+Vendor Part Number              : QSFP200I-SR4-5M
+Vendor Serial Number            : 5C2410312895
+Rev                             : 41
+Wavelength [nm]                 : 850
+Transfer Distance [m]           : 0.0
+Attenuation (5g,7g,12g,25g) [dB]: N/A
+FW Version                      : 4.116.0
+Digital Diagnostic Monitoring   : Yes
+Power Class                     : 5.0 W max
+CDR RX                          : ON,ON,ON,ON
+CDR TX                          : ON,ON,ON,ON
+LOS Alarm                       : N/A
+Temperature [C]                 : 42 [-10..80]
+Voltage [mV]                    : 3248.9 [2970..3630]
+Bias Current [mA]               : 7.800,8.220,7.840,8.100 [3..15]
+Rx Power Current [dBm]          : -3,-2,-1,0 [-10..4]
+Tx Power Current [dBm]          : 1,2,3,4 [-8..4]
+IB Cable Width                  : 1x,2x,4x
+Memory Map Revision             : 82
+Linear Direct Drive             : 0
+Cable Breakout                  : Unspecified
+SMF Length                      : N/A
+MAX Power                       : 20
+Cable Rx AMP                    : 2
+Cable Rx Emphasis (Pre)         : 3
+Cable Rx Post Emphasis          : 3
+Cable Tx Equalization           : 0
+Wavelength Tolerance            : 10.0nm
+Module State                    : Ready state
+DataPath state [per lane]       : DPActivated,DPActivated,DPActivated,DPActivated
+Rx Output Valid [per lane]      : 0,0,0,0
+Nominal bit rate                : N/A
+Rx Power Type                   : Average power
+Manufacturing Date              : 14_11_24
+Active Set Host Compliance Code : 200GAUI-4
+Active Set Media Compliance Code: 200GBASE-SR4
+Error Code Response             : ConfigUndefined
+Module FW Fault                 : 0
+DataPath FW Fault               : 0
+Tx Fault [per lane]             : 0,0,0,0
+Tx LOS [per lane]               : 0,0,0,0
+Tx CDR LOL [per lane]           : 0,0,0,0
+Rx LOS [per lane]               : 0,0,0,0
+Rx CDR LOL [per lane]           : 0,0,0,0
+Tx Adaptive EQ Fault [per lane] : 0,0,0,0
+

--- a/collector/testdata/mlxlink_active_infiniband.txt
+++ b/collector/testdata/mlxlink_active_infiniband.txt
@@ -1,0 +1,82 @@
+
+Operational Info
+----------------
+State                           : Active
+Physical state                  : LinkUp
+Speed                           : IB-NDR
+Width                           : 4x
+FEC                             : Ethernet_Consortium_LL_50G_RS_FEC_PLR -(272,257+1)
+Loopback Mode                   : No Loopback
+Auto Negotiation                : ON
+
+Supported Info
+--------------
+Enabled Link Speed              : 0x000000e0 (NDR,HDR,EDR)
+Supported Cable Speed           : 0x000000e0 (NDR,HDR,EDR)
+
+Troubleshooting Info
+--------------------
+Status Opcode                   : 0
+Group Opcode                    : N/A
+Recommendation                  : No issue was observed
+
+Tool Information
+----------------
+Firmware Version                : 28.39.1002
+amBER Version                   : 2.08
+MFT Version                     : mft 4.22.1-307
+
+Module Info
+-----------
+Identifier                      : OSFP
+Compliance                      : IB NDR,400G-SR4
+Cable Technology                : 850 nm VCSEL
+Cable Type                      : Optical Module (separated)
+OUI                             : Other
+Vendor Name                     : Firmus
+Vendor Part Number              : OSFP400I-SR4-5M
+Vendor Serial Number            : 5C2410312316
+Rev                             : 01
+Wavelength [nm]                 : 858
+Transfer Distance [m]           : 0.0
+Attenuation (5g,7g,12g,25g) [dB]: N/A
+FW Version                      : 3.129.0
+Digital Diagnostic Monitoring   : Yes
+Power Class                     : 8.0 W max
+CDR RX                          : ON,ON,ON,ON
+CDR TX                          : ON,ON,ON,ON
+LOS Alarm                       : N/A
+Temperature [C]                 : 45 [-10..80]
+Voltage [mV]                    : 3258.2 [2970..3630]
+Bias Current [mA]               : 8.440,8.480,8.340,8.400 [6.5..9.5]
+Rx Power Current [dBm]          : -3,-2,-1,0 [-8..4]
+Tx Power Current [dBm]          : 1,2,3,4 [-6..4]
+IB Cable Width                  : 1x,2x,4x
+Memory Map Revision             : 82
+Linear Direct Drive             : 0
+Cable Breakout                  : Unspecified
+SMF Length                      : N/A
+MAX Power                       : 32
+Cable Rx AMP                    : 2
+Cable Rx Emphasis (Pre)         : 3
+Cable Rx Post Emphasis          : 2
+Cable Tx Equalization           : 0
+Wavelength Tolerance            : 10.0nm
+Module State                    : Ready state
+DataPath state [per lane]       : DPActivated,DPActivated,DPActivated,DPActivated
+Rx Output Valid [per lane]      : 0,0,0,0
+Nominal bit rate                : N/A
+Rx Power Type                   : Average power
+Manufacturing Date              : 09_11_24
+Active Set Host Compliance Code : IB NDR
+Active Set Media Compliance Code: 400G-SR4
+Error Code Response             : ConfigUndefined
+Module FW Fault                 : 0
+DataPath FW Fault               : 0
+Tx Fault [per lane]             : 0,0,0,0
+Tx LOS [per lane]               : 0,0,0,0
+Tx CDR LOL [per lane]           : 0,0,0,0
+Rx LOS [per lane]               : 0,0,0,0
+Rx CDR LOL [per lane]           : 0,0,0,0
+Tx Adaptive EQ Fault [per lane] : 0,0,0,0
+

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,11 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+)
+
+require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
@@ -34,6 +39,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/stretchr/testify v1.10.0
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=


### PR DESCRIPTION
### Background

There are currently no unit tests for for parsing mlxlink output which means it's easy to accidentally break something when making other changes (this happened recently).

### What has changed

* Replaced unnecessary lookup functions with map lookups
* Reorganised mlxlink output parsing to make it easier to test
* Added basic Ethernet/Infiniband mlxlink output parsing tests

### How to review
* Confirm unit tests run successfully and confirm correct behaviour
    go test -v ./collector