### PR TITLE
BAK-1034 Add port label

### DIFF
--- a/collector/nic-module_test.go
+++ b/collector/nic-module_test.go
@@ -16,11 +16,12 @@ func TestActiveEthernet(t *testing.T) {
 		caName:     "mlx5_0",
 		netDev:     "ib0",
 	}
-	result := parseOutput(testMlxlinkOutput, "hostname", "systemserial", "slot", deviceInfo)
+	result := parseOutput(testMlxlinkOutput, "hostname", "systemserial", "slot", "1", deviceInfo)
 	expected := PortMetrics{
 		hostname:         "hostname",
 		systemserial:     "systemserial",
 		slot:             "slot",
+		port:             "1",
 		mode:             "ethernet",
 		caname:           "mlx5_0",
 		netdev:           "ib0",
@@ -65,11 +66,12 @@ func TestActiveInfiniband(t *testing.T) {
 		caName:     "mlx5_0",
 		netDev:     "ib0",
 	}
-	result := parseOutput(testMlxlinkOutput, "hostname", "systemserial", "slot", deviceInfo)
+	result := parseOutput(testMlxlinkOutput, "hostname", "systemserial", "slot", "1", deviceInfo)
 	expected := PortMetrics{
 		hostname:         "hostname",
 		systemserial:     "systemserial",
 		slot:             "slot",
+		port:             "1",
 		mode:             "infiniband",
 		caname:           "mlx5_0",
 		netdev:           "ib0",


### PR DESCRIPTION
### Background

We currently label metrics with slot number, caname and netdev for metrics reported by smc-exporter in addition to other metadata labels, however where devices are passed through caname and netdev labels will not be populated which may result in duplicated metrics where a device has a number of ports.   We should include the port (device function number for these devices) as a label to uniquely identify what port the metrics relate to independent of whether caname/netdev can be determined.

### What has changed

Map device function number returned by lspci to physical port number (add 1).   The assumption here is that for mellanox nics device function numbers correspond to physical ports.  For example slot 40 normally has two physical ports in our hardware configuration and others have 1 and this is indicated by the device function number present at the end of the pci address

### How to review
Build using build.sh and transfer t a test server
Run smc-exporter on an unused port e.g.

    build/smc-exporter-0.6.0-a.Dev-linux-amd64 -port 2114
View metrics

    wget "http://localhost:2114/metrics"
Each metric should now include a port label indicating the physical port to which the metrics relate.