### PR TITLE
Fix flag order for mlxlink

### DIFF
--- a/collector/nic-module.go
+++ b/collector/nic-module.go
@@ -687,7 +687,7 @@ func discoverMellanoxDevices() ([]DeviceInfo, error) {
 }
 
 func (n *NicModuleCollector) runMlxlink(hostname, systemserial, slot, port string, device DeviceInfo, resp chan runMlxlinkResponse) {
-	cmd := exec.Command("mlxlink", "-json", "-d", device.pciAddress, "-m", "-c", "--rx_fec_histogram", "--show_histogram") // #nosec G204
+	cmd := exec.Command("mlxlink", "-d", device.pciAddress, "-json", "-m", "-c", "--rx_fec_histogram", "--show_histogram") // #nosec G204
 	output, err := cmd.CombinedOutput()
 	mlxout := gjson.Parse(string(output))
 	valid_output := false


### PR DESCRIPTION
Newer mlxlink versions do not allow option flags before the -d flag. This change moves the -d flag to be first, with the rest at the back which is also backward compatible with the old mlxlink version.