### PR TITLE
update mapping of auto negotiation state due to the update from mlxlink

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Lint
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           args: --verbose
-          version: v2.0.2
+          version: v2.4.0

--- a/collector/nic-module.go
+++ b/collector/nic-module.go
@@ -131,6 +131,7 @@ type runMlxlinkResponse struct {
 	error  bool
 }
 
+// values of PHY state of both Ethernet and Infiniband
 var stateValues = map[string]float64{
 	"Disable":         0,
 	"Port PLL Down":   1,
@@ -191,15 +192,19 @@ var speed2bps = map[string]float64{
 	"10M":  10000000,
 }
 
+// values of auto negotiation state for both Infiniband and Ethernet
 var physicalStateValues = map[string]float64{
-	"Disabled":                   0,
-	"Initializing":               1,
-	"Recover Config":             2,
-	"Config Test":                3,
-	"Wait Remote Test":           4,
-	"Wait Config Enhanced":       5,
-	"Config Idle":                6,
-	"LinkUp":                     7,
+	// Infiniband physical state, IB_AN_FSM_*
+	"N/A":                  0,
+	"Initializing":         1,
+	"Recover Config":       2,
+	"Config Test":          3,
+	"Wait Remote Test":     4,
+	"Wait Config Enhanced": 5,
+	"Config Idle":          6,
+	// Common physical state for both Infiniband and Ethernet
+	"LinkUp": 7,
+	// Ethernet physical state, ETH_AN_FSM_*
 	"ETH_AN_FSM_ENABLE":          10,
 	"ETH_AN_FSM_XMIT_DISABLE":    11,
 	"ETH_AN_FSM_ABILITY_DETECT":  12,

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module smc-exporter
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.9
+toolchain go1.25.9
 
 require (
 	github.com/gin-gonic/gin v1.10.0


### PR DESCRIPTION
## Background

- https://firmus.atlassian.net/browse/BAK-1484
- https://github.com/Mellanox/mstflint/commit/5e6f0676449e986971b967ea96450aa26b40273c#commitcomment-159307336

## What has changed

Due to the change of mapping state on "mlxlink". Update the mapping of "Auto-Negotiation" state from "Disabled" to "N/A"

## How to review
- Read the link of [mlxlink](https://github.com/Mellanox/mstflint/commit/5e6f0676449e986971b967ea96450aa26b40273c#commitcomment-159307336) for the changes to know the mapping.
- With regard to these comments, you can read this [code](https://github.com/Mellanox/mstflint/blob/e8212fff936378a4b56d85e88ad5e0b75bd57c7f/mlxlink/modules/mlxlink_commander.cpp#L2143-L2144) to find out the "Physical State" in mlxlink are derived from Infiniband and Ethernet.



